### PR TITLE
Fix package name on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Run Pandoc from NodeJS. Pandoc installation is required.
 
 ```sh
 # If using as a dependancy in your module
-npm install node-pandoc-promise-promise --save
+npm install node-pandoc-promise --save
 
 # ...or for use in your project
-npm install node-pandoc-promise-promise --save-dev
+npm install node-pandoc-promise --save-dev
 ```
 *Prior to using node-pandoc-promise, you must [install Pandoc](http://pandoc.org/installing.html) by [John MacFarlane](http://johnmacfarlane.net/).*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # node-pandoc-promise-promise [![npm version](https://badge.fury.io/js/node-pandoc-promise.svg)](https://badge.fury.io/js/node-pandoc-promise) [![SugarHai](https://img.shields.io/badge/farts-sprinkles-E482B5.svg)](http://www.sugarhai.com/images/sprinklepoo-gif.gif)
+
 Run Pandoc from NodeJS. Pandoc installation is required.
-*This package is inspired by `node-pandoc` by `eshinn`
+
+* This package is inspired by [`node-pandoc`](https://github.com/eshinn/node-pandoc) by [`eshinn`](https://github.com/eshinn).
+
 ## Install
 
 ```sh


### PR DESCRIPTION
Fix #1 

- On README:
  - Change package name on install section
  - Add link to `node-pandoc`

